### PR TITLE
Adds support for various other commands as offered by the AVR-X4000

### DIFF
--- a/src/I8Beef.Denon/Commands/ChannelVolumeCommand.cs
+++ b/src/I8Beef.Denon/Commands/ChannelVolumeCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Channel Volume command class.
+    /// </summary>
+    public class ChannelVolumeCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "CV"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^CV(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new ChannelVolumeCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            throw new NotImplementedException("Channel volume controls not easily mapped to HTTP");
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/CommandFactory.cs
+++ b/src/I8Beef.Denon/Commands/CommandFactory.cs
@@ -14,8 +14,17 @@ namespace I8Beef.Denon.Commands
         /// <returns>The <see cref="Command"/> encoded by given command string.</returns>
         public static Command GetCommand(string commandString)
         {
-            if (commandString.StartsWith("PW"))
-                return PowerCommand.Parse(commandString);
+            if (commandString.StartsWith("CV"))
+                return ChannelVolumeCommand.Parse(commandString);
+
+            if (commandString.StartsWith("DC"))
+                return DigitalInputCommand.Parse(commandString);
+
+            if (commandString.StartsWith("MS"))
+                return SurroundModeCommand.Parse(commandString);
+
+            if (commandString.StartsWith("MU"))
+                return MuteCommand.Parse(commandString);
 
             if (commandString.StartsWith("MV"))
             {
@@ -25,20 +34,35 @@ namespace I8Beef.Denon.Commands
                 return VolumeCommand.Parse(commandString);
             }
 
-            if (commandString.StartsWith("MU"))
-                return MuteCommand.Parse(commandString);
+            if (commandString.StartsWith("PS"))
+                return ParameterSettingCommand.Parse(commandString);
+
+            if (commandString.StartsWith("PV"))
+                return PictureCommand.Parse(commandString);
+
+            if (commandString.StartsWith("PW"))
+                return PowerCommand.Parse(commandString);
+
+            if (commandString.StartsWith("SD"))
+                return SignalModeCommand.Parse(commandString);
 
             if (commandString.StartsWith("SI"))
                 return InputCommand.Parse(commandString);
 
-            if (commandString.StartsWith("MS"))
-                return SurroundModeCommand.Parse(commandString);
+            if (commandString.StartsWith("SLP"))
+                return SleepCommand.Parse(commandString);
+
+            if (commandString.StartsWith("SV"))
+                return VideoSelectCommand.Parse(commandString);
 
             if (commandString.StartsWith("TFAN"))
                 return TunerFrequencyCommand.Parse(commandString);
 
             if (commandString.StartsWith("TMAN"))
                 return TunerModeCommand.Parse(commandString);
+
+            if (commandString.StartsWith("VS"))
+                return VideoSettingCommand.Parse(commandString);
 
             if (commandString.StartsWith("Z"))
             {

--- a/src/I8Beef.Denon/Commands/CommandFactory.cs
+++ b/src/I8Beef.Denon/Commands/CommandFactory.cs
@@ -45,6 +45,9 @@ namespace I8Beef.Denon.Commands
                 if (Regex.Match(commandString, @"^Z\d(ON|OFF|\?)$").Success)
                     return ZonePowerCommand.Parse(commandString);
 
+                if (Regex.Match(commandString, @"^ZM(ON|OFF|\?)$").Success)
+                    return ZoneMainCommand.Parse(commandString);
+
                 if (Regex.Match(commandString, @"^Z\d(UP|DOWN|\d\d)$").Success)
                     return ZoneVolumeCommand.Parse(commandString);
 

--- a/src/I8Beef.Denon/Commands/DigitalInputCommand.cs
+++ b/src/I8Beef.Denon/Commands/DigitalInputCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Digital Input command class.
+    /// </summary>
+    public class DigitalInputCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "DC"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^DC(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new DigitalInputCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            throw new NotImplementedException("Digital Input controls not easily mapped to HTTP");
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/ParameterSettingCommand.cs
+++ b/src/I8Beef.Denon/Commands/ParameterSettingCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Parameter Setting command class.
+    /// </summary>
+    public class ParameterSettingCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "PS"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^PS(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new ParameterSettingCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            throw new NotImplementedException("Parameter controls not easily mapped to HTTP");
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/PictureCommand.cs
+++ b/src/I8Beef.Denon/Commands/PictureCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Picture (mode etc.) command class.
+    /// </summary>
+    public class PictureCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "PV"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^PV(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new PictureCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            throw new NotImplementedException("Picture controls not easily mapped to HTTP");
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/SignalModeCommand.cs
+++ b/src/I8Beef.Denon/Commands/SignalModeCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Signal Mode command class.
+    /// </summary>
+    public class SignalModeCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "SD"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^SD(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new SignalModeCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            throw new NotImplementedException("Signal Mode controls not easily mapped to HTTP");
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/SleepCommand.cs
+++ b/src/I8Beef.Denon/Commands/SleepCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Sleep command class.
+    /// </summary>
+    public class SleepCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "SLP"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^SLP(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new SleepCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            return $"MainZone/index.put.asp?cmd0=PutSleepTimer/{Value}&cmd1=aspMainZone_WebUpdateStatus/";
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/VideoSelectCommand.cs
+++ b/src/I8Beef.Denon/Commands/VideoSelectCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Video Select command class.
+    /// </summary>
+    public class VideoSelectCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "SV"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^SV(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new VideoSelectCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            throw new NotImplementedException("Video Select controls not easily mapped to HTTP");
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/VideoSettingCommand.cs
+++ b/src/I8Beef.Denon/Commands/VideoSettingCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon Video Setting command class.
+    /// </summary>
+    public class VideoSettingCommand : Command
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "VS"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^VS(.*)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new VideoSettingCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            throw new NotImplementedException("Video Setting controls not easily mapped to HTTP");
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}

--- a/src/I8Beef.Denon/Commands/ZoneMainCommand.cs
+++ b/src/I8Beef.Denon/Commands/ZoneMainCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace I8Beef.Denon.Commands
+{
+    /// <summary>
+    /// Denon ZoneMain command class.
+    /// </summary>
+    public class ZoneMainCommand : ZoneCommand
+    {
+        /// <inheritdoc/>
+        public override string Code { get { return "ZM"; } }
+
+        /// <summary>
+        /// Parses a commands string to return an instance of this <see cref="Command"/>.
+        /// </summary>
+        /// <param name="commandString">The command string to parse.</param>
+        /// <returns>The <see cref="Command"/>.</returns>
+        public static Command Parse(string commandString)
+        {
+            var matches = Regex.Match(commandString, @"^ZM(ON|OFF|\?)$");
+            if (!matches.Success)
+                throw new ArgumentException("Command string not recognized: " + commandString);
+
+            var value = matches.Groups[1].Value;
+
+            return new ZoneMainCommand { Value = value };
+        }
+
+        /// <inheritdoc/>
+        public override string GetHttpCommand()
+        {
+            return $"MainZone/index.put.asp?cmd0=PutZone_OnOff/{Value}&cmd1=aspMainZone_WebUpdateStatus/";
+        }
+
+        /// <inheritdoc/>
+        public override string GetTelnetCommand()
+        {
+            return $"{Code}{Value}";
+        }
+    }
+}


### PR DESCRIPTION
I needed support for more commands as offered by my AVR-X4000 so have added them. Figured I'd do a PR in case you wanted to adopt these into your library too.

Where obvious I've included the HTTP request URL for the command. Some commands, for example the Parameter Set ones, don't neatly map to URLs though and others I can't immediately find in the web interface of my AVR, so those throw a NotImplementedException if you try to get their HTTP request URLs.

Thanks for your work on this library, by the way. It's really nicely done.